### PR TITLE
fix: Update dependabot.yml to resolve labeling conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,22 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "npm"
-    commit-message:
-      prefix: "npm"
-      include: "scope"
+    open-pull-requests-limit: 5
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+      production-dependencies:
+        dependency-type: "production"
+        patterns:
+          - "@actions/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "github-actions"
-    commit-message:
-      prefix: "github-actions"
-      include: "scope" 
+    open-pull-requests-limit: 3 


### PR DESCRIPTION
## Summary
- Remove labels configuration from dependabot.yml to prevent conflicts with PR labeler workflow
- Apply Liquibase organization best practices for dependabot configuration

## Problem
Dependabot PRs were failing because:
1. The dependabot.yml file specified labels that don't exist in the repository
2. Multiple labeling systems (dependabot.yml, labeler.yml, release-drafter.yml) were conflicting
3. The PR labeler workflow was trying to apply labels without proper permissions

## Solution
Updated dependabot.yml to:
- Remove all label specifications (let labeler.yml handle labeling via PR labeler workflow)
- Remove commit-message configuration for simpler setup
- Add dependency grouping to reduce PR noise (all dev dependencies in one PR)
- Lower PR limits to manageable levels (5 for npm, 3 for GitHub Actions)
- Follow Liquibase organization patterns (weekly updates, no day/time scheduling)

## Test Plan
- [ ] Verify dependabot PRs no longer fail with label permission errors
- [ ] Confirm PR labeler workflow correctly labels dependabot PRs based on file changes
- [ ] Check that dependency updates are properly grouped

## References
- Jira: DAT-20276
- Related discussion about release automation and labeling conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)