### PR TITLE
fix: Update Liquibase Pro configuration to use environment variable

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -146,7 +146,7 @@ export async function setupLiquibase(options: LiquibaseSetupOptions): Promise<Li
   
   // Configure Pro license if this is a Pro installation
   if (edition === 'pro' && licenseKey) {
-    await configureLiquibasePro(toolPath, licenseKey);
+    configureLiquibaseProEnvironment(licenseKey);
   }
   
   // Verify that the installation was successful
@@ -240,24 +240,22 @@ async function extractLiquibase(downloadPath: string): Promise<string> {
 }
 
 /**
- * Configures Liquibase Pro by creating a properties file with the license key
+ * Configures Liquibase Pro by setting the license key as an environment variable
+ * This is more secure than writing to a properties file on disk
  * 
- * @param toolPath - Directory where Liquibase is installed
  * @param licenseKey - Pro license key to configure
  */
-async function configureLiquibasePro(toolPath: string, licenseKey: string): Promise<void> {
+function configureLiquibaseProEnvironment(licenseKey: string): void {
   try {
     // Validate license key format (basic validation)
     if (!licenseKey.trim()) {
       throw new Error('License key cannot be empty');
     }
     
-    // Create liquibase.properties file in the installation directory
-    const propertiesPath = path.join(toolPath, 'liquibase.properties');
-    const propertiesContent = `liquibase.licenseKey=${licenseKey.trim()}\n`;
-    
-    await fs.promises.writeFile(propertiesPath, propertiesContent);
-    core.info('Configured Liquibase Pro license key');
+    // Set the license key as an environment variable that Liquibase will read
+    // This is more secure than writing to a properties file
+    process.env.LIQUIBASE_LICENSE_KEY = licenseKey.trim();
+    core.info('Configured Liquibase Pro license key via environment variable');
   } catch (error) {
     throw new Error(`Failed to configure Liquibase Pro license: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -252,6 +252,9 @@ function configureLiquibaseProEnvironment(licenseKey: string): void {
       throw new Error('License key cannot be empty');
     }
     
+    // Mask the license key in GitHub Actions logs to prevent accidental exposure
+    core.setSecret(licenseKey.trim());
+    
     // Set the license key as an environment variable that Liquibase will read
     // This is more secure than writing to a properties file
     process.env.LIQUIBASE_LICENSE_KEY = licenseKey.trim();


### PR DESCRIPTION
This pull request refactors the Liquibase Pro license configuration in the `src/installer.ts` file to improve security and simplify the setup process. The most notable change is replacing the creation of a properties file with the use of an environment variable to store the license key.

### Refactoring for improved security:

* [`src/installer.ts`](diffhunk://#diff-36a9847d245bd66dd946fe257334eb7bbe0c728d37d53df8b8173c7e3eecd5b2L243-R258): Replaced the `configureLiquibasePro` function with `configureLiquibaseProEnvironment`, which sets the Liquibase Pro license key as an environment variable instead of writing it to a `liquibase.properties` file. This approach is more secure as it avoids storing sensitive data on disk.

### Simplification of setup logic:

* [`src/installer.ts`](diffhunk://#diff-36a9847d245bd66dd946fe257334eb7bbe0c728d37d53df8b8173c7e3eecd5b2L149-R149): Updated the `setupLiquibase` function to call the new `configureLiquibaseProEnvironment` function directly, removing the need to pass the installation directory (`toolPath`).