### PR TITLE
fix: Add secure-edition UAT scope and dual-version support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
       id: setup-liquibase
       uses: ./
       with:
-        version: '5.0.0'
+        version: '5.0.1'
         edition: 'community'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -18,10 +18,16 @@ on:
         - integration
         - performance
         - error-handling
-      liquibase_version:
-        description: 'Liquibase version to test (optional)'
+        - secure-edition
+      community_version:
+        description: 'Community edition version to test'
         required: false
-        default: '5.0.0'
+        default: '5.0.1'
+        type: string
+      secure_version:
+        description: 'Secure edition version to test'
+        required: false
+        default: '5.0.3'
         type: string
   schedule:
     # Run weekly on Sundays at 2 AM UTC for regular health checks
@@ -61,7 +67,7 @@ jobs:
       id: setup-liquibase
       uses: ./
       with:
-        version: ${{ inputs.liquibase_version || matrix.version || '5.0.0' }}
+        version: ${{ inputs.community_version || matrix.version || '5.0.1' }}
         edition: 'community'
     
     - name: Verify Installation and Platform Compatibility
@@ -155,7 +161,7 @@ jobs:
       id: setup-integration
       uses: ./
       with:
-        version: ${{ inputs.liquibase_version || '5.0.0' }}
+        version: ${{ inputs.community_version || '5.0.1' }}
         edition: 'community'
       env:
         # Test path transformation logging with common problematic paths
@@ -258,8 +264,8 @@ jobs:
         PATH_OUTPUT="${{ steps.setup-integration.outputs.liquibase-path }}"
         
         # Validate outputs
-        if [[ "$VERSION_OUTPUT" != *"${{ inputs.liquibase_version || '5.0.0' }}"* ]]; then
-          echo "❌ Version output mismatch: expected ${{ inputs.liquibase_version || '5.0.0' }}, got $VERSION_OUTPUT"
+        if [[ "$VERSION_OUTPUT" != *"${{ inputs.community_version || '5.0.1' }}"* ]]; then
+          echo "❌ Version output mismatch: expected ${{ inputs.community_version || '5.0.1' }}, got $VERSION_OUTPUT"
           exit 1
         fi
         echo "✅ Version output validated: $VERSION_OUTPUT"
@@ -382,7 +388,7 @@ jobs:
       continue-on-error: true
       id: invalid-edition
       with:
-        version: ${{ inputs.liquibase_version || '5.0.0' }}
+        version: ${{ inputs.community_version || '5.0.1' }}
         edition: 'invalid-edition'
     
     - name: Verify Invalid Edition Failed
@@ -494,7 +500,7 @@ jobs:
       id: setup-secure
       uses: ./
       with:
-        version: ${{ inputs.liquibase_version || '5.0.0' }}
+        version: ${{ inputs.secure_version || '5.0.3' }}
         edition: 'secure'
       env:
         LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
@@ -540,7 +546,7 @@ jobs:
       id: setup-pro-compat
       uses: ./
       with:
-        version: ${{ inputs.liquibase_version || '5.0.0' }}
+        version: ${{ inputs.secure_version || '5.0.3' }}
         edition: 'pro'
       env:
         LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
@@ -613,7 +619,7 @@ jobs:
       id: fresh-install
       uses: ./
       with:
-        version: ${{ inputs.liquibase_version || '5.0.0' }}
+        version: ${{ inputs.community_version || '5.0.1' }}
         edition: 'community'
     
     - name: Measure Fresh Install Performance
@@ -628,7 +634,7 @@ jobs:
       id: second-install
       uses: ./
       with:
-        version: ${{ inputs.liquibase_version || '5.0.0' }}
+        version: ${{ inputs.community_version || '5.0.1' }}
         edition: 'community'
             
     - name: Measure Second Install Performance
@@ -717,10 +723,15 @@ jobs:
           echo "**Test Scope**: Scheduled (full)" >> $GITHUB_STEP_SUMMARY
         fi
         
-        if [ -n "${{ inputs.liquibase_version }}" ]; then
-          echo "**Liquibase Version**: ${{ inputs.liquibase_version }}" >> $GITHUB_STEP_SUMMARY
+        if [ -n "${{ inputs.community_version }}" ]; then
+          echo "**Community Version**: ${{ inputs.community_version }}" >> $GITHUB_STEP_SUMMARY
         else
-          echo "**Liquibase Version**: 5.0.0 (default)" >> $GITHUB_STEP_SUMMARY
+          echo "**Community Version**: 5.0.1 (default)" >> $GITHUB_STEP_SUMMARY
+        fi
+        if [ -n "${{ inputs.secure_version }}" ]; then
+          echo "**Secure Version**: ${{ inputs.secure_version }}" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "**Secure Version**: 5.0.3 (default)" >> $GITHUB_STEP_SUMMARY
         fi
         
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/examples/aws-secrets-manager.yml
+++ b/examples/aws-secrets-manager.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Liquibase Secure
         uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.3'
           edition: 'secure'
 
       # Install AWS Secrets Manager extension for license retrieval

--- a/examples/basic-usage.yml
+++ b/examples/basic-usage.yml
@@ -9,7 +9,7 @@ jobs:
       
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.1'
           edition: 'community'
       
       - name: Run Liquibase Update

--- a/examples/migration-from-docker.yml
+++ b/examples/migration-from-docker.yml
@@ -14,13 +14,13 @@ jobs:
       
       # Docker equivalent:
       # docker run --rm -v $(pwd):/liquibase/changelog \
-      #   liquibase/liquibase:5.0.0 update \
+      #   liquibase/liquibase:5.0.1 update \
       #   --changelog-file=/liquibase/changelog/changelog.xml \
       #   --url=jdbc:h2:mem:test --username=sa --password=
 
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.1'
           edition: 'community'
       
       - name: Show execution context (for debugging)
@@ -47,7 +47,7 @@ jobs:
       
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.1'
           edition: 'community'
         env:
           # These absolute paths will be automatically transformed:
@@ -81,7 +81,7 @@ jobs:
       # docker run --rm \
       #   -v $(pwd):/liquibase/changelog \
       #   -v /path/to/custom-driver.jar:/liquibase/lib/custom-driver.jar \
-      #   liquibase/liquibase:5.0.0
+      #   liquibase/liquibase:5.0.1
 
       - name: Download custom database driver
         run: |
@@ -91,7 +91,7 @@ jobs:
       
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.1'
           edition: 'community'
         env:
           # Point to downloaded JAR in workspace
@@ -115,7 +115,7 @@ jobs:
       
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.1'
           edition: 'community'
         env:
           # Environment-specific log files (will be transformed)
@@ -146,7 +146,7 @@ jobs:
       
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.1'
           edition: 'community'
         env:
           LIQUIBASE_LOG_FILE: reports/liquibase.log
@@ -194,7 +194,7 @@ jobs:
 
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.3'
           edition: 'secure'
         env:
           LIQUIBASE_LOG_FILE: /liquibase/secure-logs/liquibase.log
@@ -223,7 +223,7 @@ jobs:
       
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.1'
           edition: 'community'
         env:
           LIQUIBASE_LOG_FILE: /liquibase/debug/liquibase.log

--- a/examples/secure-usage.yml
+++ b/examples/secure-usage.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: liquibase/setup-liquibase@v2
         with:
-          version: '5.0.0'
+          version: '5.0.3'
           edition: 'secure'
 
       - name: Run Secure Features


### PR DESCRIPTION
## Summary

- Adds `secure-edition` to UAT test_scope workflow dispatch options (addresses CodeRabbit finding)
- Replaces single `liquibase_version` input with separate edition-specific inputs to support divergent release versions:
  - `community_version` (default: 5.0.1) for Community edition tests
  - `secure_version` (default: 5.0.3) for Secure edition tests
- Updates all UAT jobs to use appropriate version input based on edition tested
- Updates UAT summary to display both version inputs
- Updates all example files with correct versions based on edition:
  - **Community edition examples**: 5.0.1 (latest community release)
  - **Secure edition examples**: 5.0.3 (latest secure release)
- Updates CI smoke test to use community version 5.0.1

## Changes

| File | Change |
|------|--------|
| `.github/workflows/uat-test.yml` | Add `secure-edition` option, replace `liquibase_version` with `community_version` + `secure_version` |
| `.github/workflows/test.yml` | Update smoke test to 5.0.1 |
| `examples/basic-usage.yml` | Update to 5.0.1 |
| `examples/migration-from-docker.yml` | Update community examples to 5.0.1, secure to 5.0.3 |
| `examples/secure-usage.yml` | Update to 5.0.3 |
| `examples/aws-secrets-manager.yml` | Update to 5.0.3 |

## Test plan

- [ ] CI tests pass
- [ ] Verify UAT workflow shows new inputs (`community_version`, `secure_version`) in dropdown
- [ ] Run UAT with default values to validate both editions use correct versions
- [ ] Run UAT with `secure-edition` scope to validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)