### PR TITLE
docs: Add lpm add idempotency workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,38 @@ steps:
       --password=${{ secrets.DB_PASSWORD }}
 ```
 
+### Handling Already-Installed Packages
+
+> **Note**: The `lpm add` command returns exit code 1 when a package is already installed. This can cause CI/CD workflows to fail on subsequent runs.
+
+#### Recommended: Use `--skip-existing` Flag
+
+```yaml
+- name: Install PostgreSQL Driver
+  run: liquibase lpm add postgresql --global --skip-existing
+```
+
+This ensures the command succeeds (exit 0) even if packages are already installed.
+
+#### Alternative: Ignore Exit Code
+
+**Linux/macOS:**
+```yaml
+- name: Install PostgreSQL Driver
+  run: liquibase lpm add postgresql --global || true
+```
+
+**Windows PowerShell:**
+```yaml
+- name: Install PostgreSQL Driver
+  shell: pwsh
+  run: |
+    liquibase lpm add postgresql --global
+    exit 0
+```
+
+> **Tracking**: [setup-liquibase#119](https://github.com/liquibase/setup-liquibase/issues/119)
+
 ### Learn More
 
 For complete documentation on using LPM, including:


### PR DESCRIPTION
## Summary
- Document the `--skip-existing` flag and alternative workarounds for handling already-installed packages in CI/CD workflows
- Add "Handling Already-Installed Packages" section to README
- Provide cross-platform workarounds for older lpm versions

## Related Issues
Closes #119

## Test plan
- [ ] Verify documentation renders correctly on GitHub
- [ ] Test workaround examples in actual workflow

## Notes
This PR documents both the new `--skip-existing` flag (being added in liquibase/liquibase-package-manager#585) and workarounds for older versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)