### PR TITLE
fix(DAT-22682): pin all GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4 
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -76,7 +76,7 @@ jobs:
           token: ${{ steps.get-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -193,7 +193,7 @@ jobs:
           token: ${{ steps.get-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -386,7 +386,7 @@ jobs:
           echo '```yaml' >> /tmp/changelog_entry.md
           echo 'steps:' >> /tmp/changelog_entry.md
           echo '  - name: Setup Liquibase' >> /tmp/changelog_entry.md
-          echo '    uses: liquibase/setup-liquibase@4c4338845f94675734bc4116f57701f7d761b5c0 # v2 env.VERSION }}' >> /tmp/changelog_entry.md
+          echo '    uses: liquibase/setup-liquibase@v${{ env.VERSION }}' >> /tmp/changelog_entry.md
           echo '    with:' >> /tmp/changelog_entry.md
           echo '      version: '"'"'4.32.0'"'"'' >> /tmp/changelog_entry.md
           echo '      edition: '"'"'community'"'"'' >> /tmp/changelog_entry.md
@@ -659,7 +659,7 @@ jobs:
             git push origin "$MAJOR_TAG" --force
             
             echo "✅ Updated $MAJOR_TAG tag to point to $FULL_TAG"
-            echo "Users can now reference this action with: uses: liquibase/setup-liquibase@4c4338845f94675734bc4116f57701f7d761b5c0" # v2
+            echo "Users can now reference this action with: uses: liquibase/setup-liquibase@$MAJOR_TAG"
           else
             echo "❌ Release $FULL_TAG not found, skipping major tag update"
             exit 1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -45,14 +45,14 @@ jobs:
     steps:
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -60,7 +60,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
@@ -70,7 +70,7 @@ jobs:
           permission-packages: write
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.get-token.outputs.token }}
@@ -97,7 +97,7 @@ jobs:
         run: npm run package
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: build-artifacts-${{ matrix.os }}
           path: |
@@ -114,14 +114,14 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -129,7 +129,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
@@ -141,14 +141,14 @@ jobs:
           permission-issues: write
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.get-token.outputs.token }}
 
       # Draft release notes as PRs are merged
       - name: Update Release Draft
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           config-name: release-drafter.yml
         env:
@@ -162,14 +162,14 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -177,7 +177,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
@@ -187,7 +187,7 @@ jobs:
           permission-packages: write
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.get-token.outputs.token }}
@@ -302,7 +302,7 @@ jobs:
           echo "✅ Build output verified successfully for GitHub Actions"
 
       - name: Download build artifacts from Ubuntu
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-artifacts-ubuntu-latest
           path: /tmp/artifacts
@@ -386,7 +386,7 @@ jobs:
           echo '```yaml' >> /tmp/changelog_entry.md
           echo 'steps:' >> /tmp/changelog_entry.md
           echo '  - name: Setup Liquibase' >> /tmp/changelog_entry.md
-          echo '    uses: liquibase/setup-liquibase@v${{ env.VERSION }}' >> /tmp/changelog_entry.md
+          echo '    uses: liquibase/setup-liquibase@4c4338845f94675734bc4116f57701f7d761b5c0 # v2 env.VERSION }}' >> /tmp/changelog_entry.md
           echo '    with:' >> /tmp/changelog_entry.md
           echo '      version: '"'"'4.32.0'"'"'' >> /tmp/changelog_entry.md
           echo '      edition: '"'"'community'"'"'' >> /tmp/changelog_entry.md
@@ -466,7 +466,7 @@ jobs:
       - name: Create New Release (Fallback)
         if: steps.find-draft.outputs.outcome == 'create_new'
         id: create-release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: "v${{ env.VERSION }}"
           name: "v${{ env.VERSION }}"
@@ -602,14 +602,14 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_release == 'true'
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -617,7 +617,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
@@ -626,7 +626,7 @@ jobs:
           permission-actions: write
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.get-token.outputs.token }}
           fetch-depth: 0
@@ -659,7 +659,7 @@ jobs:
             git push origin "$MAJOR_TAG" --force
             
             echo "✅ Updated $MAJOR_TAG tag to point to $FULL_TAG"
-            echo "Users can now reference this action with: uses: liquibase/setup-liquibase@$MAJOR_TAG"
+            echo "Users can now reference this action with: uses: liquibase/setup-liquibase@4c4338845f94675734bc4116f57701f7d761b5c0" # v2
           else
             echo "❌ Release $FULL_TAG not found, skipping major tag update"
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     # Checkout the repository code
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     # Setup Node.js environment with npm caching for faster builds
     - name: Setup Node.js Environment
@@ -86,7 +86,7 @@ jobs:
     steps:
     # Checkout the repository code
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     # Setup Node.js environment with npm caching
     - name: Setup Node.js Environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     
     # Setup Node.js environment with npm caching for faster builds
     - name: Setup Node.js Environment
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '24'
         cache: 'npm'
@@ -90,7 +90,7 @@ jobs:
     
     # Setup Node.js environment with npm caching
     - name: Setup Node.js Environment
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '24'
         cache: 'npm'

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -145,7 +145,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Setup Node.js Environment
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '24'
         cache: 'npm'
@@ -335,7 +335,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Setup Node.js Environment
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '24'
         cache: 'npm'
@@ -464,7 +464,7 @@ jobs:
         parse-json-secrets: true
 
     - name: Setup Node.js Environment
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '24'
         cache: 'npm'
@@ -603,7 +603,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Setup Node.js Environment
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '24'
         cache: 'npm'

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -61,7 +61,7 @@ jobs:
             version: '5.0.0'
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Setup Liquibase
       id: setup-liquibase
@@ -142,7 +142,7 @@ jobs:
     
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Setup Node.js Environment
       uses: actions/setup-node@v6
@@ -332,7 +332,7 @@ jobs:
     
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Setup Node.js Environment
       uses: actions/setup-node@v6
@@ -447,17 +447,17 @@ jobs:
     
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Configure AWS credentials for vault access
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
       with:
         role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Get secrets from vault
       id: vault-secrets
-      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
       with:
         secret-ids: |
           ,/vault/liquibase
@@ -600,7 +600,7 @@ jobs:
     
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Setup Node.js Environment
       uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Pins all third-party GitHub Action references to immutable commit SHAs
- Uses `@SHA # vX.Y.Z` format so Dependabot can continue tracking version updates
- Follows canonical SHA list maintained in liquibase/build-logic

## Security Impact
Prevents supply chain attacks where a compromised action maintainer could silently repoint a mutable version tag (e.g. `@v4`) to inject malicious code into workflows that handle AWS credentials, secrets, and publishing.

## Test Plan
- [ ] Verify no unpinned tags remain: `grep -rn 'uses:.*@v[0-9]' .github/` returns zero results for known actions
- [ ] Workflow syntax is valid

Closes DAT-22682. Part of DAT-21269.