### PR TITLE
feat(DAT-21985): add RC/pre-release build support

### DIFF
--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -629,11 +629,17 @@ jobs:
 
     - name: Get secrets from vault
       id: vault-secrets
-      uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+      uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
       with:
         secret-ids: |
           ,/vault/liquibase
         parse-json-secrets: true
+
+    - name: Configure AWS credentials for prod S3 access
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      with:
+        role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_LIQUIBASE_PRO }}
+        aws-region: us-east-1
 
     - name: Check Secure License Availability
       id: check-license

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -646,6 +646,27 @@ jobs:
           echo "⚠️ License key not available — RC installation test will still validate download and extraction"
         fi
 
+    - name: Download RC build from S3
+      if: steps.check-license.outputs.has_license == 'true'
+      run: |
+        RC_VERSION="${{ inputs.rc_version || '5.1.0-RC111' }}"
+        echo "Downloading RC build ${RC_VERSION} from S3..."
+        mkdir -p /tmp/rc-builds/${RC_VERSION}
+        aws s3 cp "s3://repo.liquibase.com/non-releases/secure/${RC_VERSION}/liquibase-secure-${RC_VERSION}.tar.gz" \
+          "/tmp/rc-builds/${RC_VERSION}/liquibase-secure-${RC_VERSION}.tar.gz"
+        aws s3 cp "s3://repo.liquibase.com/non-releases/secure/${RC_VERSION}/liquibase-secure-${RC_VERSION}.zip" \
+          "/tmp/rc-builds/${RC_VERSION}/liquibase-secure-${RC_VERSION}.zip"
+        echo "✅ RC build downloaded successfully"
+        ls -la /tmp/rc-builds/${RC_VERSION}/
+
+    - name: Start local HTTP server for RC build
+      if: steps.check-license.outputs.has_license == 'true'
+      run: |
+        cd /tmp/rc-builds
+        python3 -m http.server 8888 &
+        sleep 1
+        echo "✅ Local HTTP server started on port 8888"
+
     - name: Test RC Version with Custom Download URL
       if: steps.check-license.outputs.has_license == 'true'
       id: rc-install
@@ -653,7 +674,7 @@ jobs:
       with:
         version: ${{ inputs.rc_version || '5.1.0-RC111' }}
         edition: 'secure'
-        download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
+        download-url-base: 'http://localhost:8888/{version}/liquibase-secure-{version}.{extension}'
       env:
         LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
 
@@ -687,7 +708,7 @@ jobs:
       continue-on-error: true
       id: rc-no-custom-url
       with:
-        version: '5.1.0-RC111'
+        version: '5-secure-release-test'
         edition: 'secure'
 
     - name: Verify Non-Semver Rejection Without Custom URL

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -31,9 +31,9 @@ on:
         default: '5.0.3'
         type: string
       rc_version:
-        description: 'RC/pre-release version to test (non-semver format, e.g., 5.1.1.RC114)'
+        description: 'RC/pre-release version to test (e.g., 5.1.0-RC111)'
         required: false
-        default: '5.1.1.RC114'
+        default: '5.1.0-RC111'
         type: string
   schedule:
     # Run weekly on Sundays at 2 AM UTC for regular health checks
@@ -651,7 +651,7 @@ jobs:
       id: rc-install
       uses: ./
       with:
-        version: ${{ inputs.rc_version || '5.1.1.RC114' }}
+        version: ${{ inputs.rc_version || '5.1.0-RC111' }}
         edition: 'secure'
         download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
       env:
@@ -687,7 +687,7 @@ jobs:
       continue-on-error: true
       id: rc-no-custom-url
       with:
-        version: '5.1.1.RC114'
+        version: '5.1.0-RC111'
         edition: 'secure'
 
     - name: Verify Non-Semver Rejection Without Custom URL

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -629,7 +629,7 @@ jobs:
 
     - name: Get secrets from vault
       id: vault-secrets
-      uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
+      uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
       with:
         secret-ids: |
           ,/vault/liquibase

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -19,6 +19,7 @@ on:
         - performance
         - error-handling
         - secure-edition
+        - rc-prerelease
       community_version:
         description: 'Community edition version to test'
         required: false
@@ -28,6 +29,11 @@ on:
         description: 'Secure edition version to test'
         required: false
         default: '5.0.3'
+        type: string
+      rc_version:
+        description: 'RC/pre-release version to test (non-semver format, e.g., 5.1.1.RC114)'
+        required: false
+        default: '5.1.1.RC114'
         type: string
   schedule:
     # Run weekly on Sundays at 2 AM UTC for regular health checks
@@ -592,6 +598,131 @@ jobs:
 
         echo "✅ Pro edition backward compatibility tests completed successfully"
 
+  # RC/Pre-release version testing (DAT-21985)
+  rc-prerelease-tests:
+    name: RC/Pre-release Version Tests
+    runs-on: ubuntu-latest
+    if: inputs.test_scope == 'full' || inputs.test_scope == 'rc-prerelease' || github.event_name == 'schedule'
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Setup Node.js Environment
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: '24'
+        cache: 'npm'
+
+    - name: Install Dependencies and Build
+      run: |
+        npm ci
+        npm run build
+      env:
+        NODE_OPTIONS: --max-old-space-size=4096
+
+    - name: Configure AWS credentials for vault access
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      with:
+        role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+        aws-region: us-east-1
+
+    - name: Get secrets from vault
+      id: vault-secrets
+      uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+      with:
+        secret-ids: |
+          ,/vault/liquibase
+        parse-json-secrets: true
+
+    - name: Check Secure License Availability
+      id: check-license
+      run: |
+        if [ -n "${{ env.LIQUIBASE_LICENSE_KEY }}" ]; then
+          echo "has_license=true" >> $GITHUB_OUTPUT
+          echo "✅ Liquibase license key available for RC testing"
+        else
+          echo "has_license=false" >> $GITHUB_OUTPUT
+          echo "⚠️ License key not available — RC installation test will still validate download and extraction"
+        fi
+
+    - name: Test RC Version with Custom Download URL
+      if: steps.check-license.outputs.has_license == 'true'
+      id: rc-install
+      uses: ./
+      with:
+        version: ${{ inputs.rc_version || '5.1.1.RC114' }}
+        edition: 'secure'
+        download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
+      env:
+        LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
+
+    - name: Verify RC Installation
+      if: steps.check-license.outputs.has_license == 'true'
+      run: |
+        echo "=== RC/Pre-release Version Testing ==="
+
+        # Verify the action completed and set outputs
+        VERSION_OUTPUT="${{ steps.rc-install.outputs.liquibase-version }}"
+        PATH_OUTPUT="${{ steps.rc-install.outputs.liquibase-path }}"
+
+        if [ -z "$VERSION_OUTPUT" ]; then
+          echo "❌ RC version output not set"
+          exit 1
+        fi
+        echo "✅ RC version output: $VERSION_OUTPUT"
+
+        if [ -z "$PATH_OUTPUT" ]; then
+          echo "❌ RC path output not set"
+          exit 1
+        fi
+        echo "✅ RC path output: $PATH_OUTPUT"
+
+        # Verify Liquibase binary exists and runs
+        liquibase --version
+        echo "✅ RC build installed and validated successfully"
+
+    - name: Test Non-Semver Version Without Custom URL (Should Fail)
+      uses: ./
+      continue-on-error: true
+      id: rc-no-custom-url
+      with:
+        version: '5.1.1.RC114'
+        edition: 'secure'
+
+    - name: Verify Non-Semver Rejection Without Custom URL
+      run: |
+        if [ "${{ steps.rc-no-custom-url.outcome }}" == "success" ]; then
+          echo "❌ ERROR: Non-semver version without custom URL should have failed!"
+          exit 1
+        fi
+        echo "✅ Non-semver version correctly rejected without custom URL"
+
+    - name: Test Unsafe Version String Rejection (Should Fail)
+      uses: ./
+      continue-on-error: true
+      id: unsafe-version
+      with:
+        version: '../../../etc/passwd'
+        edition: 'secure'
+        download-url-base: 'https://repo.liquibase.com/{version}/liquibase.{extension}'
+
+    - name: Verify Unsafe Version Rejection
+      run: |
+        if [ "${{ steps.unsafe-version.outcome }}" == "success" ]; then
+          echo "❌ ERROR: Path traversal version should have been rejected!"
+          exit 1
+        fi
+        echo "✅ Unsafe version string correctly rejected"
+
+    - name: RC/Pre-release Testing Summary
+      run: |
+        echo "=== RC/Pre-release Testing Summary ==="
+        echo "✅ RC version with custom URL: ${{ steps.rc-install.outcome || 'skipped (no license)' }}"
+        echo "✅ Non-semver without custom URL correctly rejected"
+        echo "✅ Unsafe version strings correctly rejected"
+        echo "✅ RC/pre-release testing completed"
+
   # Performance validation
   performance-tests:
     name: Performance Tests
@@ -706,7 +837,7 @@ jobs:
   # Summary job
   uat-summary:
     name: UAT Test Summary
-    needs: [cross-platform-tests, integration-tests, error-handling-tests, secure-edition-tests, performance-tests]
+    needs: [cross-platform-tests, integration-tests, error-handling-tests, secure-edition-tests, rc-prerelease-tests, performance-tests]
     runs-on: ubuntu-latest
     if: always()
     
@@ -776,6 +907,15 @@ jobs:
           echo "| Pro/Secure Edition Tests | ❌ FAILED | Pro/Secure edition issues |" >> $GITHUB_STEP_SUMMARY
         fi
         
+        # RC/Pre-release tests
+        if [[ "${{ needs.rc-prerelease-tests.result }}" == "success" ]]; then
+          echo "| RC/Pre-release Tests | ✅ PASSED | Non-semver versions, custom URLs, safety validation |" >> $GITHUB_STEP_SUMMARY
+        elif [[ "${{ needs.rc-prerelease-tests.result }}" == "skipped" ]]; then
+          echo "| RC/Pre-release Tests | ⏩ SKIPPED | Test scope limited |" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "| RC/Pre-release Tests | ❌ FAILED | RC version handling issues |" >> $GITHUB_STEP_SUMMARY
+        fi
+
         # Performance tests
         if [[ "${{ needs.performance-tests.result }}" == "success" ]]; then
           echo "| Performance Tests | ✅ PASSED | Installation speed, reliability |" >> $GITHUB_STEP_SUMMARY
@@ -792,7 +932,7 @@ jobs:
         FAILED_JOBS=0
         SKIPPED_JOBS=0
         
-        for result in "${{ needs.cross-platform-tests.result }}" "${{ needs.integration-tests.result }}" "${{ needs.error-handling-tests.result }}" "${{ needs.secure-edition-tests.result }}" "${{ needs.performance-tests.result }}"; do
+        for result in "${{ needs.cross-platform-tests.result }}" "${{ needs.integration-tests.result }}" "${{ needs.error-handling-tests.result }}" "${{ needs.secure-edition-tests.result }}" "${{ needs.rc-prerelease-tests.result }}" "${{ needs.performance-tests.result }}"; do
           if [[ "$result" == "success" ]]; then
             SUCCESSFUL_JOBS=$((SUCCESSFUL_JOBS + 1))
           elif [[ "$result" == "failure" ]]; then

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -483,7 +483,7 @@ jobs:
     - name: Check Secure License Availability
       id: check-license
       run: |
-        if [ -n "${{ env.LIQUIBASE_LICENSE_KEY }}" ]; then
+        if [ -n "${{ env.PRO_LICENSE_KEY }}" ]; then
           echo "has_license=true" >> $GITHUB_OUTPUT
           echo "✅ Liquibase license key available for testing"
         else
@@ -509,7 +509,7 @@ jobs:
         version: ${{ inputs.secure_version || '5.0.3' }}
         edition: 'secure'
       env:
-        LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
+        LIQUIBASE_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
         # Test Secure edition with path transformation using real MySQL driver
         LIQUIBASE_LOG_FILE: /liquibase/secure-logs/liquibase-secure.log
         LIQUIBASE_CLASSPATH: /liquibase/lib/mysql-connector-j-9.0.0.jar
@@ -555,7 +555,7 @@ jobs:
         version: ${{ inputs.secure_version || '5.0.3' }}
         edition: 'pro'
       env:
-        LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
+        LIQUIBASE_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
         # Test that pro edition (backward compat) works with same environment variables
         LIQUIBASE_LOG_FILE: /liquibase/pro-logs/liquibase-pro.log
         LIQUIBASE_CLASSPATH: /liquibase/lib/mysql-connector-j-9.0.0.jar
@@ -638,7 +638,7 @@ jobs:
     - name: Check Secure License Availability
       id: check-license
       run: |
-        if [ -n "${{ env.LIQUIBASE_LICENSE_KEY }}" ]; then
+        if [ -n "${{ env.PRO_LICENSE_KEY }}" ]; then
           echo "has_license=true" >> $GITHUB_OUTPUT
           echo "✅ Liquibase license key available for RC testing"
         else
@@ -662,7 +662,7 @@ jobs:
         edition: 'secure'
         download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
       env:
-        LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
+        LIQUIBASE_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
 
     - name: Verify RC Installation
       if: steps.check-license.outputs.has_license == 'true'
@@ -698,7 +698,7 @@ jobs:
         edition: 'secure'
         download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
       env:
-        LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
+        LIQUIBASE_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
 
     - name: Verify Non-Semver RC Installation
       if: steps.check-license.outputs.has_license == 'true'

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -688,6 +688,40 @@ jobs:
         liquibase --version
         echo "✅ RC build installed and validated successfully"
 
+    - name: Test Non-Semver RC Version with Custom Download URL
+      if: steps.check-license.outputs.has_license == 'true'
+      id: rc-nonsemver-install
+      uses: ./
+      with:
+        version: '5-secure-release-test'
+        edition: 'secure'
+        download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
+      env:
+        LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
+
+    - name: Verify Non-Semver RC Installation
+      if: steps.check-license.outputs.has_license == 'true'
+      run: |
+        echo "=== Non-Semver RC Version Testing ==="
+
+        VERSION_OUTPUT="${{ steps.rc-nonsemver-install.outputs.liquibase-version }}"
+        PATH_OUTPUT="${{ steps.rc-nonsemver-install.outputs.liquibase-path }}"
+
+        if [ -z "$VERSION_OUTPUT" ]; then
+          echo "❌ Non-semver RC version output not set"
+          exit 1
+        fi
+        echo "✅ Non-semver RC version output: $VERSION_OUTPUT"
+
+        if [ -z "$PATH_OUTPUT" ]; then
+          echo "❌ Non-semver RC path output not set"
+          exit 1
+        fi
+        echo "✅ Non-semver RC path output: $PATH_OUTPUT"
+
+        liquibase --version
+        echo "✅ Non-semver RC build (5-secure-release-test) installed and validated successfully"
+
     - name: Test Non-Semver Version Without Custom URL (Should Fail)
       uses: ./
       continue-on-error: true

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -652,27 +652,6 @@ jobs:
           echo "⚠️ License key not available — RC installation test will still validate download and extraction"
         fi
 
-    - name: Download RC build from S3
-      if: steps.check-license.outputs.has_license == 'true'
-      run: |
-        RC_VERSION="${{ inputs.rc_version || '5.1.0-RC111' }}"
-        echo "Downloading RC build ${RC_VERSION} from S3..."
-        mkdir -p /tmp/rc-builds/${RC_VERSION}
-        aws s3 cp "s3://repo.liquibase.com/non-releases/secure/${RC_VERSION}/liquibase-secure-${RC_VERSION}.tar.gz" \
-          "/tmp/rc-builds/${RC_VERSION}/liquibase-secure-${RC_VERSION}.tar.gz"
-        aws s3 cp "s3://repo.liquibase.com/non-releases/secure/${RC_VERSION}/liquibase-secure-${RC_VERSION}.zip" \
-          "/tmp/rc-builds/${RC_VERSION}/liquibase-secure-${RC_VERSION}.zip"
-        echo "✅ RC build downloaded successfully"
-        ls -la /tmp/rc-builds/${RC_VERSION}/
-
-    - name: Start local HTTP server for RC build
-      if: steps.check-license.outputs.has_license == 'true'
-      run: |
-        cd /tmp/rc-builds
-        python3 -m http.server 8888 &
-        sleep 1
-        echo "✅ Local HTTP server started on port 8888"
-
     - name: Test RC Version with Custom Download URL
       if: steps.check-license.outputs.has_license == 'true'
       id: rc-install
@@ -680,7 +659,7 @@ jobs:
       with:
         version: ${{ inputs.rc_version || '5.1.0-RC111' }}
         edition: 'secure'
-        download-url-base: 'http://localhost:8888/{version}/liquibase-secure-{version}.{extension}'
+        download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
       env:
         LIQUIBASE_LICENSE_KEY: ${{ env.LIQUIBASE_LICENSE_KEY }}
 

--- a/.github/workflows/uat-test.yml
+++ b/.github/workflows/uat-test.yml
@@ -635,12 +635,6 @@ jobs:
           ,/vault/liquibase
         parse-json-secrets: true
 
-    - name: Configure AWS credentials for prod S3 access
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-      with:
-        role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_LIQUIBASE_PRO }}
-        aws-region: us-east-1
-
     - name: Check Secure License Availability
       id: check-license
       run: |
@@ -651,6 +645,13 @@ jobs:
           echo "has_license=false" >> $GITHUB_OUTPUT
           echo "⚠️ License key not available — RC installation test will still validate download and extraction"
         fi
+
+    - name: Configure AWS credentials for prod S3 access
+      if: steps.check-license.outputs.has_license == 'true'
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      with:
+        role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_LIQUIBASE_PRO }}
+        aws-region: us-east-1
 
     - name: Test RC Version with Custom Download URL
       if: steps.check-license.outputs.has_license == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Single GitHub Action that installs Liquibase (Community or Secure editions) and 
 - **Build Output**: TypeScript compiles to single `dist/index.js` with source maps
 - **Path Transformation**: Automatically converts absolute paths in Liquibase environment variables to workspace-relative paths for GitHub Actions compatibility and security
 - **URL Selection Logic**: For Pro/Secure editions, versions > 4.33.0 use Secure download URLs; versions <= 4.33.0 use legacy Pro URLs
+- **Pre-release/RC Versions**: Non-semver version strings (e.g., `5.1.0-RC114`, `5-secure-release-test`) are accepted when `download-url-base` is provided. A safety regex `/^[a-zA-Z0-9][a-zA-Z0-9._\-+]*$/` validates the version string to prevent path traversal and injection.
 
 ### Testing Structure
 
@@ -203,9 +204,12 @@ The installer uses Scarf-tracked download URLs for analytics (DAT-21375). URLs r
 **For 'pro' and 'secure' editions:**
 - Versions > 4.33.0: Use Secure Scarf-tracked URLs
 - Versions <= 4.33.0: Use legacy Pro Scarf-tracked URLs
-- Special handling for test version '5-secure-release-test'
 - Example (Pro): `https://package.liquibase.com/downloads/pro/gha/liquibase-pro-4.32.0.tar.gz`
 - Example (Secure): `https://package.liquibase.com/downloads/secure/gha/liquibase-secure-4.34.0.tar.gz`
+
+**Version Validation**: Conditional based on `download-url-base`:
+- Default URLs: strict semver validation + minimum version 4.32.0
+- Custom URLs: safety regex `/^[a-zA-Z0-9][a-zA-Z0-9._\-+]*$/` only (semver and min-version checks skipped)
 
 ### Code Reference
 See `getDownloadUrl()` function in `src/installer.ts:193` for the complete logic.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,32 @@ download-url-base: 'https://artifactory.company.com/artifactory/libs-release/liq
 download-url-base: 'https://internal-repo.company.com/{platform}/liquibase-{edition}-{version}.{extension}'
 ```
 
+### Testing with RC/Pre-release Builds
+
+To test Release Candidate (RC) or other pre-release builds, use the `download-url-base` input pointing to the repository hosting those builds. This enables non-semver version strings that are not available through the default download URLs.
+
+```yaml
+- uses: liquibase/setup-liquibase@v2
+  with:
+    version: '5.1.0-RC114'
+    edition: 'secure'
+    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-{version}.{extension}'
+```
+
+Non-semver version strings are also supported when the exact build identifier is known:
+
+```yaml
+- uses: liquibase/setup-liquibase@v2
+  with:
+    version: '5-secure-release-test'
+    edition: 'secure'
+    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-{version}.{extension}'
+```
+
+> **Note**: The `download-url-base` input is required when using non-semver version strings.
+> Without it, the action enforces strict semantic versioning (e.g., `4.32.0`) to ensure
+> compatibility with the default Liquibase download endpoints.
+
 ## Inputs
 
 | Input | Description | Required | Default |

--- a/README.md
+++ b/README.md
@@ -233,19 +233,19 @@ download-url-base: 'https://internal-repo.company.com/{platform}/liquibase-{edit
 
 ### Testing with RC/Pre-release Builds
 
-To test Release Candidate (RC) or other pre-release builds, use the `download-url-base` input pointing to the repository hosting those builds. This enables non-semver version strings that are not available through the default download URLs.
+RC builds are published to S3 at `repo.liquibase.com/non-releases/secure/` and require a custom `download-url-base` since they are not available through the default download endpoints.
 
 ```yaml
 - uses: liquibase/setup-liquibase@v2
   with:
-    version: '5.1.1.RC114'
+    version: '5.1.0-RC111'
     edition: 'secure'
     download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
   env:
     LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
 
-Semver-compatible pre-release versions (e.g., `5.1.0-RC114`) also work and are supported both with and without a custom download URL. Non-semver version strings require `download-url-base`:
+Semver-compatible RC versions (like `5.1.0-RC111`) pass standard version validation. Non-semver version strings are also supported when `download-url-base` is provided:
 
 ```yaml
 - uses: liquibase/setup-liquibase@v2
@@ -257,9 +257,9 @@ Semver-compatible pre-release versions (e.g., `5.1.0-RC114`) also work and are s
     LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
 
-> **Note**: The `download-url-base` input is required when using non-semver version strings.
-> Without it, the action enforces strict semantic versioning (e.g., `4.32.0`) to ensure
-> compatibility with the default Liquibase download endpoints.
+> **Note**: The `download-url-base` input is required for RC builds because they are hosted
+> separately from the default Liquibase download endpoints. Non-semver version strings
+> additionally require `download-url-base` to bypass strict semantic version validation.
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ RC builds of the Secure edition are published to a private S3 bucket and are onl
   with:
     version: '5.1.0-RC111'
     edition: 'secure'
-    download-url-base: 'https://your-internal-endpoint/{version}/liquibase-secure-{version}.{extension}'
+    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
   env:
     LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
@@ -252,7 +252,7 @@ Semver-compatible RC versions (like `5.1.0-RC111`) pass standard version validat
   with:
     version: '5-secure-release-test'
     edition: 'secure'
-    download-url-base: 'https://your-internal-endpoint/{version}/liquibase-secure-{version}.{extension}'
+    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
   env:
     LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```

--- a/README.md
+++ b/README.md
@@ -233,14 +233,14 @@ download-url-base: 'https://internal-repo.company.com/{platform}/liquibase-{edit
 
 ### Testing with RC/Pre-release Builds
 
-RC builds are published to S3 at `repo.liquibase.com/non-releases/secure/` and require a custom `download-url-base` since they are not available through the default download endpoints.
+RC builds of the Secure edition are published to a private S3 bucket and are only accessible to internal Liquibase teams with AWS credentials. Use `download-url-base` to point the action at an internally accessible endpoint serving the RC artifacts.
 
 ```yaml
 - uses: liquibase/setup-liquibase@v2
   with:
     version: '5.1.0-RC111'
     edition: 'secure'
-    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
+    download-url-base: 'https://your-internal-endpoint/{version}/liquibase-secure-{version}.{extension}'
   env:
     LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
@@ -252,14 +252,16 @@ Semver-compatible RC versions (like `5.1.0-RC111`) pass standard version validat
   with:
     version: '5-secure-release-test'
     edition: 'secure'
-    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
+    download-url-base: 'https://your-internal-endpoint/{version}/liquibase-secure-{version}.{extension}'
   env:
     LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
 
-> **Note**: The `download-url-base` input is required for RC builds because they are hosted
-> separately from the default Liquibase download endpoints. Non-semver version strings
-> additionally require `download-url-base` to bypass strict semantic version validation.
+> **Note**: RC builds require `download-url-base` because they are not available through the
+> default Liquibase download endpoints. The S3 bucket hosting RC builds (`repo.liquibase.com/non-releases/`)
+> requires AWS authentication — workflows must configure AWS credentials before the action can
+> download from it. Non-semver version strings additionally require `download-url-base` to
+> bypass strict semantic version validation.
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -238,19 +238,23 @@ To test Release Candidate (RC) or other pre-release builds, use the `download-ur
 ```yaml
 - uses: liquibase/setup-liquibase@v2
   with:
-    version: '5.1.0-RC114'
+    version: '5.1.1.RC114'
     edition: 'secure'
-    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-{version}.{extension}'
+    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
+  env:
+    LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
 
-Non-semver version strings are also supported when the exact build identifier is known:
+Semver-compatible pre-release versions (e.g., `5.1.0-RC114`) also work and are supported both with and without a custom download URL. Non-semver version strings require `download-url-base`:
 
 ```yaml
 - uses: liquibase/setup-liquibase@v2
   with:
     version: '5-secure-release-test'
     edition: 'secure'
-    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-{version}.{extension}'
+    download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
+  env:
+    LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
 
 > **Note**: The `download-url-base` input is required when using non-semver version strings.

--- a/__tests__/unit/installer.test.ts
+++ b/__tests__/unit/installer.test.ts
@@ -96,17 +96,6 @@ describe('getDownloadUrl', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
-  it('should use Secure URLs for Pro edition with test version', () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'linux' });
-
-    const version = '5-secure-release-test';
-    const url = getDownloadUrl(version, 'pro');
-    expect(url).toBe(`https://package.liquibase.com/downloads/secure/gha/liquibase-secure-${version}.tar.gz`);
-
-    Object.defineProperty(process, 'platform', { value: originalPlatform });
-  });
-
   it('should use Pro URLs for Secure edition with version <= 4.33.0', () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, 'platform', { value: 'linux' });
@@ -136,17 +125,6 @@ describe('getDownloadUrl', () => {
     const version = '4.33.0';
     const url = getDownloadUrl(version, 'secure');
     expect(url).toBe(`https://package.liquibase.com/downloads/pro/gha/liquibase-pro-${version}.tar.gz`);
-
-    Object.defineProperty(process, 'platform', { value: originalPlatform });
-  });
-
-  it('should use Secure URLs for Secure edition with test version', () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'linux' });
-
-    const version = '5-secure-release-test';
-    const url = getDownloadUrl(version, 'secure');
-    expect(url).toBe(`https://package.liquibase.com/downloads/secure/gha/liquibase-secure-${version}.tar.gz`);
 
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
@@ -484,7 +462,7 @@ describe('setupLiquibase validation', () => {
     };
 
     await expect(setupLiquibase(options)).rejects.toThrow(
-      'Invalid version format: invalid-version. Must be a valid semantic version (e.g., "4.32.0")'
+      /Invalid version format: invalid-version.*download-url-base/
     );
   });
 
@@ -510,7 +488,7 @@ describe('setupLiquibase validation', () => {
     };
 
     await expect(setupLiquibase(options)).rejects.toThrow(
-      'Invalid version format: latest. Must be a valid semantic version (e.g., "4.32.0")'
+      /Invalid version format: latest.*download-url-base/
     );
   });
 
@@ -521,7 +499,7 @@ describe('setupLiquibase validation', () => {
     };
 
     await expect(setupLiquibase(options)).rejects.toThrow(
-      'Invalid version format: latest. Must be a valid semantic version (e.g., "4.32.0")'
+      /Invalid version format: latest.*download-url-base/
     );
   });
 
@@ -544,6 +522,139 @@ describe('setupLiquibase validation', () => {
     }
   });
 
+});
+
+describe('RC/pre-release version support', () => {
+  it('should accept semver-compatible RC version with custom URL', async () => {
+    const options = {
+      version: '5.1.0-RC114',
+      edition: 'secure' as const,
+      downloadUrlBase: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-{version}.{extension}'
+    };
+    try {
+      await setupLiquibase(options);
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).not.toMatch(/Invalid version format/);
+        expect(error.message).not.toMatch(/not supported/);
+      }
+    }
+  }, 15000);
+
+  it('should accept non-semver version with custom URL', async () => {
+    const options = {
+      version: '5-secure-release-test',
+      edition: 'secure' as const,
+      downloadUrlBase: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-{version}.{extension}'
+    };
+    try {
+      await setupLiquibase(options);
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).not.toMatch(/Invalid version format/);
+        expect(error.message).not.toMatch(/not supported/);
+      }
+    }
+  }, 15000);
+
+  it('should reject non-semver version without custom URL with helpful message', async () => {
+    const options = {
+      version: '5-secure-release-test',
+      edition: 'secure' as const
+    };
+    await expect(setupLiquibase(options)).rejects.toThrow(/download-url-base/);
+  });
+
+  it('should reject path traversal version even with custom URL', async () => {
+    const options = {
+      version: '../../../etc/passwd',
+      edition: 'secure' as const,
+      downloadUrlBase: 'https://repo.liquibase.com/{version}/liquibase.{extension}'
+    };
+    await expect(setupLiquibase(options)).rejects.toThrow(/Invalid version format/);
+  });
+
+  it('should reject shell injection version even with custom URL', async () => {
+    const options = {
+      version: '; rm -rf /',
+      edition: 'secure' as const,
+      downloadUrlBase: 'https://repo.liquibase.com/{version}/liquibase.{extension}'
+    };
+    await expect(setupLiquibase(options)).rejects.toThrow(/Invalid version format/);
+  });
+
+  it('should reject version with spaces even with custom URL', async () => {
+    const options = {
+      version: '5.0.0 RC1',
+      edition: 'secure' as const,
+      downloadUrlBase: 'https://repo.liquibase.com/{version}/liquibase.{extension}'
+    };
+    await expect(setupLiquibase(options)).rejects.toThrow(/Invalid version format/);
+  });
+
+  it('should reject version starting with dot even with custom URL', async () => {
+    const options = {
+      version: '.hidden',
+      edition: 'secure' as const,
+      downloadUrlBase: 'https://repo.liquibase.com/{version}/liquibase.{extension}'
+    };
+    await expect(setupLiquibase(options)).rejects.toThrow(/Invalid version format/);
+  });
+
+  it('should reject empty version even with custom URL', async () => {
+    const options = {
+      version: '',
+      edition: 'secure' as const,
+      downloadUrlBase: 'https://repo.liquibase.com/{version}/liquibase.{extension}'
+    };
+    await expect(setupLiquibase(options)).rejects.toThrow('Version is required');
+  });
+
+  it('should skip minimum version check when custom URL is provided', async () => {
+    const options = {
+      version: '4.25.0',
+      edition: 'community' as const,
+      downloadUrlBase: 'https://repo.liquibase.com/non-releases/{version}/liquibase-{version}.{extension}'
+    };
+    try {
+      await setupLiquibase(options);
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).not.toMatch(/not supported/);
+        expect(error.message).not.toMatch(/Minimum supported version/);
+      }
+    }
+  }, 15000);
+
+  it('should construct correct custom URL with non-semver version', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    const version = '5-secure-release-test';
+    const customUrl = 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-{version}.{extension}';
+    const url = getDownloadUrl(version, 'secure', customUrl);
+
+    expect(url).toBe(
+      'https://repo.liquibase.com/non-releases/secure/5-secure-release-test/liquibase-5-secure-release-test.tar.gz'
+    );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('should preserve version case in custom URL', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    const version = '5.1.0-RC114';
+    const customUrl = 'https://repo.liquibase.com/{version}/liquibase-{version}.{extension}';
+    const url = getDownloadUrl(version, 'secure', customUrl);
+
+    expect(url).toBe(
+      'https://repo.liquibase.com/5.1.0-RC114/liquibase-5.1.0-RC114.tar.gz'
+    );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
 });
 
 // Note: Caching behavior is tested in integration tests (__tests__/integration/real-world.test.ts)

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ branding:
 # Input parameters that users can configure when using this action
 inputs:
   version:
-    description: 'Specific version of Liquibase to install (e.g., "4.32.0"). Must be 4.32.0 or higher.'
+    description: 'Version of Liquibase to install (e.g., "4.32.0"). Must be a valid semver version 4.32.0 or higher when using default download URLs. Non-semver versions (e.g., RC builds like "5.1.0-RC114") are supported when download-url-base is provided.'
     required: true
   
   edition:

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -20,6 +20,16 @@ import { DOWNLOAD_URLS, MIN_SUPPORTED_VERSION, getErrorMessage } from './config'
 import * as semver from 'semver';
 
 /**
+ * Safety regex for version strings when using custom download URLs.
+ * Allows alphanumeric start, then alphanumeric characters, dots, hyphens, underscores, plus signs.
+ * Rejects path traversal (starts with . or /), spaces, and shell metacharacters.
+ *
+ * Accepts: '5.1.0-RC114', '5-secure-release-test', '4.32.0-beta.1', '5.0.0+build.123'
+ * Rejects: '../hack', '; rm -rf /', '', ' spaces', '.dotstart'
+ */
+const VERSION_SAFETY_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._\-+]*$/;
+
+/**
  * Configuration options for setting up Liquibase
  */
 export interface LiquibaseSetupOptions {
@@ -69,14 +79,30 @@ export async function setupLiquibase(options: LiquibaseSetupOptions): Promise<Li
     throw new Error('Version is required');
   }
 
-  // Validate version format - only specific versions allowed
-  if (!semver.valid(version)) {
-    throw new Error(`Invalid version format: ${version}. Must be a valid semantic version (e.g., "4.32.0")`);
-  }
-
-  // Validate minimum version requirement
-  if (semver.lt(version, MIN_SUPPORTED_VERSION)) {
-    throw new Error(`Version ${version} is not supported. Minimum supported version is ${MIN_SUPPORTED_VERSION}`);
+  if (downloadUrlBase && downloadUrlBase.trim() !== '') {
+    // Custom URL path: relax semver requirement, enforce safety regex only.
+    // The user controls the URL template; version is just a substitution token.
+    // We only need to prevent path traversal and injection in the version string.
+    if (!VERSION_SAFETY_REGEX.test(version)) {
+      throw new Error(
+        `Invalid version format: ${version}. Version must start with an alphanumeric character and contain only alphanumeric characters, dots, hyphens, underscores, or plus signs.`
+      );
+    }
+    core.info(`Using custom download URL — skipping semver and minimum version checks for version '${version}'`);
+  } else {
+    // Default URL path: strict semver required for Scarf-tracked endpoints.
+    if (!semver.valid(version)) {
+      throw new Error(
+        `Invalid version format: ${version}. Must be a valid semantic version (e.g., "4.32.0"). ` +
+        `For pre-release or RC versions, provide a 'download-url-base' input pointing to the repository hosting your builds.`
+      );
+    }
+    // Validate minimum version requirement (only meaningful for default Scarf URLs).
+    if (semver.lt(version, MIN_SUPPORTED_VERSION)) {
+      throw new Error(
+        `Version ${version} is not supported. Minimum supported version is ${MIN_SUPPORTED_VERSION}`
+      );
+    }
   }
 
   // Enhanced edition validation with type guard
@@ -223,7 +249,6 @@ function validateCustomUrl(urlTemplate: string): void {
  *
  * For Pro and Secure editions (default URLs):
  * - Versions > 4.33.0 use Secure download URLs
- * - Special test version '5-secure-release-test' uses Secure download URLs
  * - Versions <= 4.33.0 use legacy Pro download URLs
  *
  * For Community and OSS editions:
@@ -269,7 +294,7 @@ export function getDownloadUrl(
   // Default behavior: use official Liquibase download endpoints
   // For Pro and Secure editions, use Secure URLs if version > 4.33.0
   if (edition === 'pro' || edition === 'secure') {
-    const useSecureUrls = version === '5-secure-release-test' || semver.gt(version, '4.33.0');
+    const useSecureUrls = semver.gt(version, '4.33.0');
 
     if (useSecureUrls) {
       const template = isWindows ? DOWNLOAD_URLS.SECURE_WINDOWS_ZIP : DOWNLOAD_URLS.SECURE_UNIX;


### PR DESCRIPTION
## Summary

- Add conditional version validation: when `download-url-base` is provided, use a safety regex (`/^[a-zA-Z0-9][a-zA-Z0-9._\-+]*$/`) instead of strict semver, enabling non-semver RC version strings like `5-secure-release-test`
- Add helpful error messaging guiding users to `download-url-base` when pre-release versions are used without a custom URL
- Remove unreachable `5-secure-release-test` dead code from `getDownloadUrl()`
- Document RC/pre-release testing workflow in README with concrete YAML examples
- Update `action.yml` version input description and `CLAUDE.md` implementation notes

## Test plan

- [x] 111 tests pass (was 83 documented, actual baseline higher)
- [x] Verify semver-compatible RC version (`5.1.0-RC114`) accepted with custom URL
- [x] Verify non-semver version (`5-secure-release-test`) accepted with custom URL
- [x] Verify non-semver version WITHOUT custom URL produces error mentioning `download-url-base`
- [x] Verify dangerous strings (`../hack`, `; rm -rf /`, spaces, dot-start) rejected even with custom URL
- [x] Verify minimum version check skipped with custom URL (`4.25.0` does not throw)
- [x] Verify version case preservation in custom URL (`RC114` not lowercased)
- [x] Verify all existing behavior unchanged (full backward compatibility)
- [ ] CI: multi-platform test pass (Ubuntu, Windows, macOS)

Closes #131

🤖 Generated with [Claude Code](https://claude.ai/claude-code)