### PR TITLE
docs: update README for v3.0.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This action provides the following functionality for GitHub Actions users:
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.0.3'
     edition: 'community'
 - run: liquibase --version
 ```
@@ -129,9 +129,9 @@ rm -rf $RUNNER_TOOL_CACHE/liquibase
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.0.3'
     edition: 'community'
 - run: liquibase --version
 ```
@@ -141,9 +141,9 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.0.3'
     edition: 'community'
 - run: liquibase update --changelog-file=changelog.xml --url=jdbc:h2:mem:test
 ```
@@ -153,9 +153,9 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.1.1'
     edition: 'secure'
 - run: liquibase update --changelog-file=changelog.xml --url=jdbc:h2:mem:test
   env:
@@ -167,9 +167,9 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.0.3'
 - run: liquibase --version
 ```
 
@@ -182,9 +182,9 @@ If your self-hosted runners are behind a firewall and need to download Liquibase
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.0.3'
     edition: 'oss'
     download-url-base: 'https://nexus.company.com/repository/liquibase/{version}/liquibase-{version}.{extension}'
 - run: liquibase --version
@@ -198,9 +198,9 @@ env:
 
 steps:
 - uses: actions/checkout@v4
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.0.3'
     edition: 'oss'
 - run: liquibase --version
 ```
@@ -236,7 +236,7 @@ download-url-base: 'https://internal-repo.company.com/{platform}/liquibase-{edit
 RC builds of the Secure edition are published to a private S3 bucket and are only accessible to internal Liquibase teams with AWS credentials. Use `download-url-base` to point the action at an internally accessible endpoint serving the RC artifacts.
 
 ```yaml
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
     version: '5.1.0-RC111'
     edition: 'secure'
@@ -248,7 +248,7 @@ RC builds of the Secure edition are published to a private S3 bucket and are onl
 Semver-compatible RC versions (like `5.1.0-RC111`) pass standard version validation. Non-semver version strings are also supported when `download-url-base` is provided:
 
 ```yaml
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
     version: '5-secure-release-test'
     edition: 'secure'
@@ -306,9 +306,9 @@ When using `edition: 'community'` with Liquibase 5.0 or later:
 
 ```yaml
 steps:
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '5.0.0'
+    version: '5.0.3'
     edition: 'community'
 
 # Install PostgreSQL driver using LPM
@@ -337,17 +337,17 @@ This action follows [semantic versioning](https://semver.org/):
 ### Version Updates
 
 - **v2.0.x** → Patch releases: Bug fixes only (backward compatible)
-- **v2.x.0** → Minor releases: New features (backward compatible)
-- **v3.0.0** → Major releases: Breaking changes
+- **v3.x.0** → Minor releases: New features (backward compatible)
+- **v4.0.0** → Major releases: Breaking changes
 
 ### Recommended Usage
 
 ```yaml
 # Recommended: Use major version tag for automatic non-breaking updates
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
 
 # Alternative: Pin to specific version for reproducibility
-- uses: liquibase/setup-liquibase@v2.0.0
+- uses: liquibase/setup-liquibase@v3.0.0
 ```
 
 ## Platform Support
@@ -377,9 +377,9 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
     
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '4.32.0'
+        version: '5.0.3'
         edition: 'community'
     
     - run: liquibase --version
@@ -397,9 +397,9 @@ The Liquibase Package Manager (LPM) is integrated into Liquibase 5.0+ and is ess
 steps:
 - uses: actions/checkout@v4
 
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '5.0.0'
+    version: '5.0.3'
     edition: 'community'
 
 - name: Install PostgreSQL Driver
@@ -476,9 +476,9 @@ jobs:
     env:
       LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
     steps:
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '4.32.0'
+        version: '5.1.1'
         edition: 'secure'
     - run: liquibase update --changelog-file=changelog.xml
     - run: liquibase checks run --changelog-file=changelog.xml
@@ -498,10 +498,9 @@ jobs:
       with:
         role-to-assume: ${{ secrets.AWS_ROLE }}
         aws-region: us-east-1
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '5.0.0'
-        edition: 'secure'
+        version: '5.1.1'\n        edition: 'secure'
     - run: |
         liquibase \
           --license-key=aws-secrets,my-liquibase-secrets,license-key \
@@ -518,9 +517,9 @@ jobs:
       with:
         role-to-assume: ${{ secrets.AWS_ROLE }}
         aws-region: us-east-1
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '4.32.0'
+        version: '5.1.1'
         edition: 'secure'
     - name: Install AWS Secrets Manager Extension
       run: |
@@ -556,9 +555,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '4.32.0'
+        version: '5.0.3'
         edition: 'community'
         
     - name: Run Liquibase Update
@@ -584,9 +583,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '4.32.0'
+        version: '5.1.1'
         edition: 'secure'
         
     - name: Validate Changelog
@@ -630,9 +629,9 @@ jobs:
         path: flow-templates
         token: ${{ secrets.GITHUB_TOKEN }}
     
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '4.32.0'
+        version: '5.1.1'
         edition: 'secure'
         
     - name: Execute Flow from Template
@@ -664,10 +663,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '5.0.0'
-        edition: 'secure'
+        version: '5.1.1'
 
     - name: Execute Flow from S3
       run: |
@@ -708,9 +706,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
-        version: '4.32.0'
+        version: '5.1.1'
         edition: 'secure'
 
     - name: Download AWS Extension
@@ -753,7 +751,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - uses: liquibase/setup-liquibase@v2
+    - uses: liquibase/setup-liquibase@v3
       with:
         version: ${{ matrix.liquibase-version }}
         edition: 'community'
@@ -845,9 +843,9 @@ If you're migrating from the official Liquibase GitHub Actions, here's how to co
 
 ### After (setup-liquibase)
 ```yaml
-- uses: liquibase/setup-liquibase@v2
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.0.3'
     edition: 'community'
 - run: liquibase update \
     --changelog-file=changelog.xml \

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ This action follows [semantic versioning](https://semver.org/):
 
 ### Version Updates
 
-- **v2.0.x** → Patch releases: Bug fixes only (backward compatible)
+- **v3.0.x** → Patch releases: Bug fixes only (backward compatible)
 - **v3.x.0** → Minor releases: New features (backward compatible)
 - **v4.0.0** → Major releases: Breaking changes
 
@@ -500,7 +500,8 @@ jobs:
         aws-region: us-east-1
     - uses: liquibase/setup-liquibase@v3
       with:
-        version: '5.1.1'\n        edition: 'secure'
+        version: '5.1.1'
+        edition: 'secure'
     - run: |
         liquibase \
           --license-key=aws-secrets,my-liquibase-secrets,license-key \
@@ -666,6 +667,7 @@ jobs:
     - uses: liquibase/setup-liquibase@v3
       with:
         version: '5.1.1'
+        edition: 'secure'
 
     - name: Execute Flow from S3
       run: |

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ jobs:
 
     - uses: liquibase/setup-liquibase@v3
       with:
-        version: '5.1.1'
+        version: '5.1.1'
         edition: 'secure'
 
     - name: Execute Flow from S3

--- a/RELEASE_AUTOMATION.md
+++ b/RELEASE_AUTOMATION.md
@@ -15,7 +15,7 @@ This document explains how the release automation works for the setup-liquibase 
 - **build-and-test**: Multi-platform build matrix (Ubuntu, Windows, macOS)
 - **draft-release**: Updates draft releases from PR merges
 - **create-release**: Creates/publishes releases (manual dispatch only)
-- **update-major-tag**: Updates major version tags (v1 → v1.x.x) after release
+- **update-major-tag**: Updates major version tags (v3 → v3.x.x) after release
 
 **Key Features:**
 - Multi-platform testing for reliability
@@ -50,7 +50,7 @@ This document explains how the release automation works for the setup-liquibase 
    - Generate dynamic changelog
    - Create/update draft release
    - Publish if requested
-   - Update major version tag (v1 → v1.2.3)
+   - Update major version tag (v3 → v3.x.x)
 
 ### Draft Release Management
 
@@ -118,7 +118,7 @@ feature:
    - **Patch (x.x.1)**: Bug fixes only (backward compatible)
    - **Minor (x.1.0)**: New features (backward compatible)
    - **Major (1.0.0)**: Breaking changes
-   - **Tags**: Major tag (v1) auto-updates to latest v1.x.x
+   - **Tags**: Major tag (v3) auto-updates to latest v3.x.x
 
 ## Troubleshooting
 
@@ -154,7 +154,7 @@ feature:
    → Dynamic changelog generated
    → Draft release updated with latest changes
    → Release published (if requested)
-   → Major version tag updated (v1 → v1.2.3)
+   → Major version tag updated (v3 → v3.x.x)
 ```
 
 This simplified system provides enterprise-grade release automation while maintaining simplicity for developers and following GitHub Actions best practices.

--- a/UAT_TESTING.md
+++ b/UAT_TESTING.md
@@ -63,7 +63,7 @@ steps:
 steps:
 - uses: liquibase/setup-liquibase@v3
   with:
-    version: '5.0.3'
+    version: '5.1.1'
     edition: 'secure'
   env:
     LIQUIBASE_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
@@ -161,7 +161,7 @@ runs-on: ${{ matrix.os }}
   uses: liquibase/setup-liquibase@v3
   id: secure-install
   with:
-    version: '5.0.3'
+    version: '5.1.1'
     edition: 'secure'
 
 - name: Verify Installation Success

--- a/UAT_TESTING.md
+++ b/UAT_TESTING.md
@@ -3,9 +3,9 @@
 This document provides comprehensive testing instructions for the setup-liquibase GitHub Action.
 
 ## Current Testing Versions
-- **Production**: `@v1` (latest stable release)
-- **Specific Version**: `@v1.0.0` (for regression testing)
-- **Pre-release**: Use specific tags when testing betas (e.g., `@v2-beta`)
+- **Production**: `@v3` (latest stable release)
+- **Specific Version**: `@v3.0.0` (for regression testing)
+- **Pre-release**: Use specific tags when testing pre-releases (e.g., `@v3.0.0`)
 
 ## Quick Start for Testers
 
@@ -28,11 +28,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Setup Liquibase OSS
-      uses: liquibase/setup-liquibase@v1
+    - name: Setup Liquibase COMMUNITY
+      uses: liquibase/setup-liquibase@v3
       with:
-        version: '4.32.0'
-        edition: 'oss'
+        version: '5.0.3'
+        edition: 'community'
     
     - name: Verify Installation
       run: |
@@ -44,7 +44,7 @@ jobs:
 
 ### 1. Basic Installation Tests
 
-#### OSS Edition Tests
+#### Community Edition Tests
 ```yaml
 strategy:
   matrix:
@@ -52,18 +52,18 @@ strategy:
     os: [ubuntu-latest, windows-latest, macos-latest]
 
 steps:
-- uses: liquibase/setup-liquibase@v1
+- uses: liquibase/setup-liquibase@v3
   with:
     version: ${{ matrix.version }}
-    edition: 'oss'
+    edition: 'community'
 ```
 
 #### Secure Edition Tests
 ```yaml
 steps:
-- uses: liquibase/setup-liquibase@v1
+- uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
+    version: '5.0.3'
     edition: 'secure'
   env:
     LIQUIBASE_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
@@ -86,10 +86,10 @@ runs-on: ${{ matrix.os }}
 #### Database Operations Test
 ```yaml
 - name: Setup Liquibase
-  uses: liquibase/setup-liquibase@v1
+  uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
-    edition: 'oss'
+    version: '5.0.3'
+    edition: 'community'
 
 - name: Create Test Changelog
   run: |
@@ -140,12 +140,12 @@ runs-on: ${{ matrix.os }}
 #### Invalid Version Test
 ```yaml
 - name: Test Invalid Version (Should Fail)
-  uses: liquibase/setup-liquibase@v1
+  uses: liquibase/setup-liquibase@v3
   continue-on-error: true
   id: invalid-version
   with:
     version: 'invalid-version'
-    edition: 'oss'
+    edition: 'community'
 
 - name: Verify Failure
   run: |
@@ -158,10 +158,10 @@ runs-on: ${{ matrix.os }}
 #### Secure Edition Installation Test
 ```yaml
 - name: Test Secure Installation (Should Succeed)
-  uses: liquibase/setup-liquibase@v1
+  uses: liquibase/setup-liquibase@v3
   id: secure-install
   with:
-    version: '4.32.0'
+    version: '5.0.3'
     edition: 'secure'
 
 - name: Verify Installation Success
@@ -178,10 +178,10 @@ runs-on: ${{ matrix.os }}
 #### Path Transformation Test
 ```yaml
 - name: Test Path Transformation (Enhanced Logging)
-  uses: liquibase/setup-liquibase@v1
+  uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
-    edition: 'oss'
+    version: '5.0.3'
+    edition: 'community'
   env:
     # These absolute paths will trigger transformation logging
     LIQUIBASE_LOG_FILE: /liquibase/changelog/test.log
@@ -207,12 +207,12 @@ runs-on: ${{ matrix.os }}
 #### Migration Guidance Test
 ```yaml
 - name: Test Enhanced Logging Output
-  uses: liquibase/setup-liquibase@v1
+  uses: liquibase/setup-liquibase@v3
   with:
-    version: '4.32.0'
-    edition: 'oss'
+    version: '5.0.3'
+    edition: 'community'
   # Look for these enhanced logging messages in the action output:
-  # 🚀 Setting up Liquibase OSS 4.32.0
+  # 🚀 Setting up Liquibase COMMUNITY 5.0.3
   # 🎯 Liquibase configuration:
   # 💡 Migration from liquibase-github-actions:
   # 🔄 Path Transformation (Security & Compatibility):
@@ -221,7 +221,7 @@ runs-on: ${{ matrix.os }}
 ## Test Checklist
 
 ### Basic Functionality ✅
-- [ ] OSS edition installs successfully
+- [ ] Community edition installs successfully
 - [ ] Secure edition installs successfully (license validation at runtime)
 - [ ] Action outputs are set correctly (liquibase-version, liquibase-path)
 - [ ] Liquibase binary is added to PATH
@@ -288,7 +288,7 @@ Copy and paste this template when reporting UAT issues:
 ## UAT Issue Report
 
 **Platform**: ubuntu-latest / windows-latest / macos-latest  
-**Liquibase Version**: 4.32.0  
+**Liquibase Version**: 5.0.3  
 **Edition**: oss / secure  
 
 **Expected Behavior**:  
@@ -345,7 +345,7 @@ The repository includes automated UAT testing via GitHub Actions:
 
 For external contributors testing this action:
 
-- ✅ **OSS Edition Tests**: Full access to all OSS functionality testing
+- ✅ **Community Edition Tests**: Full access to all Community edition functionality testing
 - ✅ **Integration Tests**: Database operations with H2 (no license required)
 - ✅ **Error Handling Tests**: Complete validation of error scenarios
 - ✅ **Performance Tests**: Installation performance validation
@@ -382,6 +382,5 @@ For questions or issues during UAT testing:
 
 After successful UAT completion:
 1. Address any found issues
-2. Create v1.0.0 release
-3. Publish to GitHub Marketplace
-4. Update documentation with marketplace availability
+2. Merge fixes and update release notes
+3. Promote pre-release to stable when validated

--- a/UAT_TESTING.md
+++ b/UAT_TESTING.md
@@ -289,7 +289,7 @@ Copy and paste this template when reporting UAT issues:
 
 **Platform**: ubuntu-latest / windows-latest / macos-latest  
 **Liquibase Version**: 5.0.3  
-**Edition**: oss / secure  
+**Edition**: community / secure  
 
 **Expected Behavior**:  
 [Describe what should happen]

--- a/docs/PATH_HANDLING.md
+++ b/docs/PATH_HANDLING.md
@@ -79,7 +79,7 @@ docker run -v $(pwd):/liquibase/changelog liquibase/liquibase:4.32.0 \
   update --changelog-file=/liquibase/changelog/changelog.xml
 
 # GitHub Actions approach  
-- uses: liquibase/setup-liquibase@v1
+- uses: liquibase/setup-liquibase@v3
 - run: liquibase update --changelog-file=changelog.xml
 ```
 
@@ -91,7 +91,7 @@ docker run -v /path/to/driver.jar:/liquibase/lib/driver.jar
 # GitHub Actions approach (download + classpath)
 - name: Download Custom Driver
   run: wget https://example.com/driver.jar -O lib/driver.jar
-- uses: liquibase/setup-liquibase@v1
+- uses: liquibase/setup-liquibase@v3
   env:
     LIQUIBASE_CLASSPATH: lib/driver.jar
 ```
@@ -102,7 +102,7 @@ docker run -v /path/to/driver.jar:/liquibase/lib/driver.jar
 docker run -e LIQUIBASE_LOG_FILE=/liquibase/logs/app.log
 
 # GitHub Actions approach (automatic transformation)
-- uses: liquibase/setup-liquibase@v1
+- uses: liquibase/setup-liquibase@v3
   env:
     LIQUIBASE_LOG_FILE: /liquibase/logs/app.log  # Becomes ./liquibase/logs/app.log
 ```
@@ -123,7 +123,7 @@ env:
 ### 2. Understand Your Working Directory
 ```yaml
 - uses: actions/checkout@v4
-- uses: liquibase/setup-liquibase@v1
+- uses: liquibase/setup-liquibase@v3
 - run: |
     pwd  # Shows: /actions-runner/_work/your-repo/your-repo
     ls   # Shows your repository files
@@ -149,7 +149,7 @@ jobs:
       LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
       LIQUIBASE_LOG_FILE: logs/liquibase.log
     steps:
-      - uses: liquibase/setup-liquibase@v1
+      - uses: liquibase/setup-liquibase@v3
       - run: liquibase update --changelog-file=changelog.xml
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to v3.0.0 stable promotion.

- Replace all `@v2` floating tag references with `@v3` (24 instances)
- Replace `@v2.0.0` pin with `@v3.0.0` in versioning section
- Update community edition version examples: `4.32.0` → `5.0.3`
- Update secure edition version examples: `4.32.0`/`5.0.0` → `5.1.1`
- Update version strategy section to reflect the v3.x line

Minimum version documentation and legacy migration examples referencing `4.32.0` intentionally preserved — those describe the minimum supported version constraint, not example usage.