### PR TITLE
docs: correct the RC download instructions (TECHOPS-1127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,19 +233,20 @@ download-url-base: 'https://internal-repo.company.com/{platform}/liquibase-{edit
 
 ### Testing with RC/Pre-release Builds
 
-RC builds of the Secure edition are published to a private S3 bucket and are only accessible to internal Liquibase teams with AWS credentials. Use `download-url-base` to point the action at an internally accessible endpoint serving the RC artifacts.
+RC builds of the Secure edition are not served by the default download endpoints, so they need
+`download-url-base` to point the action at the RC path on `repo.liquibase.com`.
 
 ```yaml
 - uses: liquibase/setup-liquibase@v3
   with:
-    version: '5.1.0-RC111'
+    version: '6.0.0-RC5'
     edition: 'secure'
     download-url-base: 'https://repo.liquibase.com/non-releases/secure/{version}/liquibase-secure-{version}.{extension}'
   env:
     LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
 
-Semver-compatible RC versions (like `5.1.0-RC111`) pass standard version validation. Non-semver version strings are also supported when `download-url-base` is provided:
+Semver-compatible RC versions (like `6.0.0-RC5`) pass standard version validation. Non-semver version strings are also supported when `download-url-base` is provided:
 
 ```yaml
 - uses: liquibase/setup-liquibase@v3
@@ -257,11 +258,20 @@ Semver-compatible RC versions (like `5.1.0-RC111`) pass standard version validat
     LIQUIBASE_LICENSE_KEY: ${{ secrets.LIQUIBASE_LICENSE_KEY }}
 ```
 
-> **Note**: RC builds require `download-url-base` because they are not available through the
-> default Liquibase download endpoints. The S3 bucket hosting RC builds (`repo.liquibase.com/non-releases/`)
-> requires AWS authentication — workflows must configure AWS credentials before the action can
-> download from it. Non-semver version strings additionally require `download-url-base` to
-> bypass strict semantic version validation.
+> **Note**: RC builds require `download-url-base` for two independent reasons: they are not
+> available through the default Liquibase download endpoints, and non-semver version strings
+> need it to bypass strict semantic version validation.
+>
+> **No credentials are involved in the download.** An earlier version of this note said
+> workflows must configure AWS credentials first. That was never true: the action performs a
+> plain unsigned HTTP GET (`downloadTool`), so it cannot present AWS credentials even when they
+> are configured, and the artifacts are on Cloudflare R2 rather than S3, which would make AWS
+> credentials the wrong type anyway. The RC path is fetchable without signing. It is simply
+> unlisted, so there is no index and you need the exact version string
+> ([TECHOPS-1127](https://datical.atlassian.net/browse/TECHOPS-1127)).
+>
+> RC artifacts are not retained forever. Substitute the RC you actually want to test rather
+> than reusing the version in the example above.
 
 ## Inputs
 


### PR DESCRIPTION
Docs half of [TECHOPS-1127](https://datical.atlassian.net/browse/TECHOPS-1127).

> [!IMPORTANT]
> **Merge after [liquibase-infrastructure#4249](https://github.com/liquibase/liquibase-infrastructure/pull/4249).** This text says the RC path is fetchable without signing, which only becomes true once that PR applies. Merging earlier would trade one inaccurate statement for another.

## The claim

> The S3 bucket hosting RC builds (`repo.liquibase.com/non-releases/`) requires AWS authentication — workflows must configure AWS credentials before the action can download from it.

## Why it is false

This action cannot use AWS credentials for a download, configured or not:

- `src/installer.ts:143` is `const downloadPath = await downloadTool(downloadUrl);`, called with a **single argument**. No auth token, no headers.
- Grepping all of `src/` (`config.ts`, `index.ts`, `installer.ts`) for `aws`, `sigv4`, `presign`, `auth`, `authorization` returns **zero matches**.

So every download is a plain unsigned GET. On top of that the artifacts are on Cloudflare R2 now, not S3, so AWS credentials would be the wrong credential type even if the action could send them.

The practical harm: anyone debugging a failed RC install follows this note, wires up `configure-aws-credentials`, still gets a 404, and has no way to tell that credentials were never involved. That is roughly what happened in #167, which attributed the May RC failures to a stale hard-coded version and repeated the "private S3, requires AWS credentials" framing.

## What actually broke

A Cloudflare rule added 2026-05-15 blanket-blocks `/non-releases/*` at the edge. This repo's own UAT job dates it: the RC job was **green on 2026-05-03** (after the R2 cutover on 04-18, so R2 was not the cause) and **red on 2026-05-17**. It has been skipped since #167 removed it from the scheduled scope.

## Changes

- Drops the AWS-credentials claim and states plainly that no credentials are involved, with the reason.
- Corrects "private S3 bucket" to the actual serving arrangement: fetchable without signing, but unlisted, so you need the exact version string.
- Replaces the `5.1.0-RC111` example, which no longer exists, and notes RC artifacts are not retained indefinitely.
- Keeps both real reasons `download-url-base` is required (not on the default endpoints, and non-semver bypass).

## Follow-up, not in this PR

`uat-test.yml`'s `rc-prerelease` job is still gated to manual dispatch only, so nothing exercises the RC path on a schedule. Rather than re-hardcoding a version here, the regression check now lives in the release pipeline itself ([liquibase-pro#4790](https://github.com/liquibase/liquibase-pro/pull/4790)): every RC release GETs its own artifacts through their public URLs and fails on a 404, which is version-agnostic and cannot rot. Restoring this job to the scheduled scope is still worth doing if you want coverage of the action itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-1127]: https://datical.atlassian.net/browse/TECHOPS-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
