### PR TITLE
[TECHOPS-1269] Gate the Claude job on author association

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,11 +21,25 @@ permissions:
 
 jobs:
   claude:
+    # Trusted authors only. Every trigger above is public: issue_comment and issues fire
+    # for any GitHub account. This job calls build-logic's claude.yml, which assumes the
+    # vault OIDC role and reads /vault/liquibase before invoking the action, so without an
+    # author gate anyone who writes "@claude" causes a credential load. Bot senders are
+    # excluded so a bot echoing the mention cannot chain into a run.
+    #
+    # build-logic's claude.yml now carries the same gate, so this is belt and braces
+    # rather than the only control. Kept here because a job skipped by the caller never
+    # starts the called workflow at all. [TECHOPS-1269]
+    #
+    # author_association hangs off a different object per event (comment, review, issue),
+    # which is why the check is repeated per branch rather than hoisted out.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     uses: liquibase/build-logic/.github/workflows/claude.yml@main
     secrets: inherit
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,18 +21,29 @@ permissions:
 
 jobs:
   claude:
-    # Trusted authors only. Every trigger above is public: issue_comment and issues fire
-    # for any GitHub account. This job calls build-logic's claude.yml, which assumes the
-    # vault OIDC role and reads /vault/liquibase before invoking the action, so without an
-    # author gate anyone who writes "@claude" causes a credential load. Bot senders are
-    # excluded so a bot echoing the mention cannot chain into a run.
+    # Trusted authors only, as a pre-filter rather than the security boundary. Every
+    # trigger above is public: issue_comment and issues fire for any GitHub account. This
+    # job calls build-logic's claude.yml, which assumes the vault OIDC role and reads
+    # /vault/liquibase before invoking the action, so without an author gate anyone who
+    # writes "@claude" causes a credential load. Bot senders are excluded so a bot echoing
+    # the mention cannot chain into a run.
+    #
+    # author_association is deliberately loose (MEMBER is any org member, COLLABORATOR
+    # includes read and triage), so claude-code-action's own write-or-admin actor check
+    # stays as the finer-grained control. The only advantage this gate has over it is
+    # timing: GitHub evaluates an `if:` before a runner exists, so a rejected event never
+    # reaches the vault at all. Scoping the secret outranks both and is TECHOPS-1108.
     #
     # build-logic's claude.yml now carries the same gate, so this is belt and braces
     # rather than the only control. Kept here because a job skipped by the caller never
     # starts the called workflow at all. [TECHOPS-1269]
     #
     # author_association hangs off a different object per event (comment, review, issue),
-    # which is why the check is repeated per branch rather than hoisted out.
+    # which is why the check is repeated per branch rather than hoisted out. On
+    # `issues: assigned` that object is the issue, so the value read is the issue author's
+    # association and not the assigner's: a member assigning an outsider's "@claude" issue
+    # is skipped. Intentional, because the body Claude would then act on is still
+    # attacker-authored.
     if: |
       github.event.sender.type != 'Bot' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||


### PR DESCRIPTION
[TECHOPS-1269](https://datical.atlassian.net/browse/TECHOPS-1269). **Belt and braces**, and a pre-filter rather than the security boundary.

Every trigger on this workflow is public. `issue_comment` and `issues` fire for **any GitHub account**. The job calls `build-logic/.github/workflows/claude.yml`, which assumes the vault OIDC role and reads all of `/vault/liquibase` with `parse-json-secrets: true` before invoking `claude-code-action`. With only a `@claude` body check, anyone could cause a full credential load on a public repository.

## Where this sits

| | Layer | What it gives | What it lacks |
|---|---|---|---|
| 1 | This `if:` | Fails closed before a runner exists, so a rejected event costs no runner, no OIDC and no vault read | Coarse. `MEMBER` is any org member and `COLLABORATOR` includes read and triage |
| 2 | `claude-code-action`'s actor check | Requires write or admin, so it is the finer-grained and standards-aligned control | Runs once the vault is already in the job environment |
| 3 | Scoping the secret | Removes the exposure instead of gating access to it | Not this change: [TECHOPS-1108](https://datical.atlassian.net/browse/TECHOPS-1108) |

Layer 2 stays and is not being replaced. Timing is the only thing this gate adds, and it is the one property the action's own check cannot provide. Layer 3 outranks both.

This copies the gate already in `liquibase/liquibase`: bot senders excluded, and `author_association` restricted to `OWNER`, `MEMBER` or `COLLABORATOR`, checked per event because that field hangs off a different object each time (comment, review, issue).

**No abuse found.** Full run history for this workflow shows every executed run was triggered by an org member. Comments from outside accounts exist, but none contained `@claude`, so those runs skipped on the mention check alone.

**Why it stays even so.** [build-logic#698](https://github.com/liquibase/build-logic/pull/698) adds the same gate to the shared workflow, which is what actually covers all 14 callers (only `liquibase/liquibase` had it). This one stays anyway, because a job skipped by the caller never starts the called workflow at all.

## Behaviour changes to know about

**`CONTRIBUTOR` is not trusted**, so someone with a merged PR who is not a collaborator loses `@claude` access here. Same as `liquibase/liquibase`.

**On `issues: assigned` the value read is the issue author's association, not the assigner's.** `github.event.issue.author_association` describes whoever opened the issue, so a member assigning an outsider's `@claude` issue is skipped. That is the outcome I want, because the body Claude would then act on is still attacker-authored, but it was only written down for `CONTRIBUTOR` before review. It is now in the comment.

## Verification

YAML parses, `actionlint` clean, and the expression was simulated against 15 synthetic payloads covering each `author_association` value, a bot sender and all four events. 15 of 15 matched the intended verdict: `NONE`, `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR` and bots skip; `OWNER`, `MEMBER`, `COLLABORATOR` run.

Re-simulated the `issues: assigned` cases after review, 8 of 8 correct:

| Case | Result |
|---|---|
| `assigned` by MEMBER, issue authored by `NONE` | **skipped** |
| `assigned` by MEMBER, issue authored by MEMBER | runs |
| `assigned` by Bot sender, issue authored by OWNER | **skipped** |


[TECHOPS-1269]: https://datical.atlassian.net/browse/TECHOPS-1269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-1108]: https://datical.atlassian.net/browse/TECHOPS-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ